### PR TITLE
Fix resigning for Enterprise env by removing beta-reports-active

### DIFF
--- a/floatsign.sh
+++ b/floatsign.sh
@@ -361,15 +361,22 @@ else
 				PlistBuddy -c "Set :keychain-access-groups:0 ${APP_IDENTIFER_PREFIX}.${BUNDLE_IDENTIFIER}" "$TEMP_DIR/newEntitlements"
 #				checkStatus  -- if this fails it's likely because the keychain-access-groups key does not exist, so we have nothing to update
 				if [[ "$CERTIFICATE" == *Distribution* ]]; then
+					IS_ENTERPRISE_PROFILE=`PlistBuddy -c "Print :ProvisionsAllDevices" "$TEMP_DIR/profile.plist" | tr -d '\n'`
 					echo "Assuming Distribution Identity"
 					if [ "$ADJUST_BETA_REPORTS_ACTIVE_FLAG" == "1" ]; then
-						echo "Ensuring beta-reports-active is present and enabled"
-						# new beta key is only used for Distribution; might not exist yet, if we were building Development
-						PlistBuddy -c "Add :beta-reports-active bool true" "$TEMP_DIR/newEntitlements"
-						if [ $? -ne 0 ]; then
-							PlistBuddy -c "Set :beta-reports-active YES" "$TEMP_DIR/newEntitlements"
+						if [ "$IS_ENTERPRISE_PROFILE" == "true" ]; then
+							echo "Ensuring beta-reports-active is not included for Enterprise environment"
+							PlistBuddy -c "Delete :beta-reports-active" "$TEMP_DIR/newEntitlements"
+							checkStatus
+						else
+							echo "Ensuring beta-reports-active is present and enabled"
+							# new beta key is only used for Distribution; might not exist yet, if we were building Development
+							PlistBuddy -c "Add :beta-reports-active bool true" "$TEMP_DIR/newEntitlements"
+							if [ $? -ne 0 ]; then
+									PlistBuddy -c "Set :beta-reports-active YES" "$TEMP_DIR/newEntitlements"
+							fi
+							checkStatus
 						fi
-						checkStatus
 					fi
 					echo "Setting get-task-allow entitlement to NO"
 					PlistBuddy -c "Set :get-task-allow NO" "$TEMP_DIR/newEntitlements"


### PR DESCRIPTION
For Enterprise distribution, the `beta-reports-active` flag always has to be removed, as this is [only valid for App Store profiles](https://developer.apple.com/library/ios/qa/qa1830/_index.html).

Currently trying to install an .ipa resigned with an enterprise profile triggers the following error when trying to install it on a device:

```
installd <Error>: entitlement 'beta-reports-active' has value not permitted by provisioning profile '<enterprise provisioning profile name>'
installd <Error>: -[MICodeSigningVerifier performValidationWithError:]: 188: Failed to verify code signature of <MIExecutableBundle : path = /private/var/mobile/Library/Caches/com.apple.mobile.installd.staging/temp.bwZuU7/extracted/Payload/... (Entitlements found that are not permitted by provisioning profile)
installd <Error>: -[MIInstaller performInstallationWithError:]: Verification stage failed
```

These changes now check if the new provisioning profile is an Enterprise profile and in this case ensure that the `beta-reports-active` is always removed.
