### PR TITLE
Resign dylibs in FRAMEWORKS_DIR to make resigned Swift apps run. #4

### DIFF
--- a/floatsign.sh
+++ b/floatsign.sh
@@ -293,7 +293,7 @@ then
 	echo "Resigning embedded frameworks using certificate: '$CERTIFICATE'" >&2
 	for framework in "$FRAMEWORKS_DIR"/*
 	do
-		if [[ "$framework" == *.framework ]]
+		if [[ "$framework" == *.framework || "$framework" == *.dylib ]]
 		then
 			/usr/bin/codesign -f -s "$CERTIFICATE" "$framework"
 			checkStatus


### PR DESCRIPTION
Without resigning the dylibs the resigned apps would crash on launch with following error:

```
amfid <Error>: /private/var/mobile/Containers/Bundle/Application/527A6055-B847-4505-89ED-D916A7B01C3E/My App.app/Frameworks/libswiftCore.dylib not valid: 0xe8008015: A valid provisioning profile for this executable was not found.
```

This should fix #4 
